### PR TITLE
Improved example; amalgamated libraries

### DIFF
--- a/examples/src/Main.cpp
+++ b/examples/src/Main.cpp
@@ -11,7 +11,7 @@
 
 using namespace nqr;
 
-int main()
+int main( int argc, const char **argv ) try
 {
 	AudioDevice::ListAudioDevices();
 
@@ -69,7 +69,7 @@ int main()
         
         //Block-split-stereo-ima4-reaper.wav
         //auto result = loader.Load(fileData, "test_data/ad_hoc/TestBeat_44_16_mono-ima4-reaper.wav");
-         loader.Load(fileData, "test_data/ad_hoc/TestBeat_44_16_stereo-ima4-reaper.wav");
+         loader.Load(fileData, argc > 1 ? argv[1] : "test_data/ad_hoc/TestBeat_44_16_stereo-ima4-reaper.wav");
 	}
     catch(const UnsupportedExtensionEx & e)
     {
@@ -114,4 +114,21 @@ int main()
     std::cout << "Encoder Status: " << encoderStatus << std::endl;
     
 	return 0;
+}
+catch(const UnsupportedExtensionEx & e)
+{
+    std::cerr << "Caught: " << e.what() << std::endl;
+}
+catch(const LoadPathNotImplEx & e)
+{
+   std::cerr << "Caught: " << e.what() << std::endl;
+}
+catch(const LoadBufferNotImplEx & e)
+{
+    std::cerr << "Caught: " << e.what() << std::endl;
+}
+catch (const std::exception & e)
+{
+	std::cerr << "Caught: " << e.what() << std::endl;
+	std::exit(1);
 }

--- a/src/OpusDependencies.c
+++ b/src/OpusDependencies.c
@@ -93,8 +93,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "opus/celt/vq.c"
 
 // Disabled inline because of name clash of opus_custom_encoder_get_size.
-//#include "opus/celt/celt_decoder.c"
-//#include "opus/celt/celt_encoder.c"
+#include "opus/celt/celt_decoder.c"
+#define opus_custom_encoder_get_size opus_custom_encoder_get_size_alt
+#include "opus/celt/celt_encoder.c"
 
 /*
     See celt/celt_decoder.c + celt/celt_encoder.c in the project browser.

--- a/src/WavPackDependencies.c
+++ b/src/WavPackDependencies.c
@@ -25,9 +25,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if (_MSC_VER)
     #pragma warning (push)
-    #pragma warning (disable: 181 111 4267 4996 4244 4701 4702 4133 4100 4127 4206 4312 4505 4365 4005 4013 4334)
+    #pragma warning (disable: 181 111 4267 4996 4244 4701 4702 4133 4100 4127 4206 4312 4505 4365 4005 4013 4334 4703)
 #endif
-
+        
 #ifdef __clang__
     #pragma clang diagnostic push
     #pragma clang diagnostic ignored "-Wconversion"
@@ -35,15 +35,29 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     #pragma clang diagnostic ignored "-Wdeprecated-register"
 #endif
 
-#include "musepack/libmpcdec/huffman.c"
-#include "musepack/libmpcdec/requant.c"
-#include "musepack/libmpcdec/streaminfo.c"
-#include "musepack/libmpcdec/synth_filter.c"
-#include "musepack/libmpcdec/crc32.c"
-#include "musepack/libmpcdec/mpc_reader.c"
-#include "musepack/libmpcdec/mpc_decoder.c"
-#include "musepack/libmpcdec/mpc_demux.c"
-#include "musepack/libmpcdec/mpc_bits_reader.c"
+#ifdef _WIN32
+#ifndef WIN32
+#define WIN32
+#endif
+#endif
+
+#include "wavpack/src/bits.c"
+#include "wavpack/src/extra1.c"
+#define WavpackExtraInfo WavpackExtraInfo_alt
+#define log2overhead log2overhead_alt
+#define xtable xtable_alt
+#include "wavpack/src/extra2.c"
+#include "wavpack/src/float.c"
+#include "wavpack/src/metadata.c"
+#define decorr_stereo_pass decorr_stereo_pass_alt
+#include "wavpack/src/pack.c"
+#include "wavpack/src/tags.c"
+#undef  decorr_stereo_pass
+#define decorr_stereo_pass decorr_stereo_pass_alt_2
+#include "wavpack/src/unpack.c"
+#include "wavpack/src/unpack3.c"
+#include "wavpack/src/words.c"
+#include "wavpack/src/wputils.c"
 
 #ifdef __clang__
     #pragma clang diagnostic pop

--- a/third_party/musepack/libmpcdec/mpc_bits_reader.h
+++ b/third_party/musepack/libmpcdec/mpc_bits_reader.h
@@ -32,6 +32,7 @@
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#pragma once
 #define MAX_ENUM 32
 
 MPC_API int mpc_bits_get_block(mpc_bits_reader * r, mpc_block * p_block);

--- a/third_party/musepack/libmpcdec/mpc_decoder.c
+++ b/third_party/musepack/libmpcdec/mpc_decoder.c
@@ -45,19 +45,19 @@
 #include "mpc_bits_reader.h"
 
 //SV7 tables
-extern const mpc_lut_data   mpc_HuffQ [7] [2];
-extern const mpc_lut_data   mpc_HuffHdr;
+extern /*const*/ mpc_lut_data   mpc_HuffQ [7] [2];
+extern /*const*/ mpc_lut_data   mpc_HuffHdr;
 extern const mpc_huffman    mpc_table_HuffSCFI [ 4];
-extern const mpc_lut_data   mpc_HuffDSCF;
+extern /*const*/ mpc_lut_data   mpc_HuffDSCF;
 
 //SV8 tables
-extern const mpc_can_data mpc_can_Bands;
-extern const mpc_can_data mpc_can_SCFI[2];
-extern const mpc_can_data mpc_can_DSCF[2];
-extern const mpc_can_data mpc_can_Res [2];
-extern const mpc_can_data mpc_can_Q [8][2];
-extern const mpc_can_data mpc_can_Q1;
-extern const mpc_can_data mpc_can_Q9up;
+extern /*const*/ mpc_can_data mpc_can_Bands;
+extern /*const*/ mpc_can_data mpc_can_SCFI[2];
+extern /*const*/ mpc_can_data mpc_can_DSCF[2];
+extern /*const*/ mpc_can_data mpc_can_Res [2];
+extern /*const*/ mpc_can_data mpc_can_Q [6/*8*/][2];
+extern /*const*/ mpc_can_data mpc_can_Q1;
+extern /*const*/ mpc_can_data mpc_can_Q9up;
 
 //------------------------------------------------------------------------------
 // types


### PR DESCRIPTION
Also, for reference, this is the batch file I am using to compile from the command-line:

```bash
cl /Zi /Oy- /MDd /DDEBUG /EHsc ^
        -I include ^
        -I include\libnyquist ^
        -I third_party ^
        -I third_party\flac\src\include ^
        -I third_party\libogg\include ^
        -I third_party\libvorbis\include ^
        -I third_party\musepack\include ^
        -I third_party\opus\celt ^
        -I third_party\opus\silk ^
        -I third_party\opus\silk\float ^
        -I third_party\opus\libopus\include ^
        -I third_party\opus\opusfile\include ^
        -I third_party\opus\opusfile\src\include ^
        -I third_party\wavpack\include ^
        src\*.c* ^
        third_party\rtaudio\RtAudio.cpp /D__WINDOWS_DS__ ole32.lib user32.lib ^
        examples\src\main.cpp
```