### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/third_party/opus/silk/enc_API.c
+++ b/third_party/opus/silk/enc_API.c
@@ -165,7 +165,7 @@ opus_int silk_Encode(                                   /* O    Returns error co
     psEnc->state_Fxx[ 0 ].sCmn.nFramesEncoded = psEnc->state_Fxx[ 1 ].sCmn.nFramesEncoded = 0;
 
     /* Check values in encoder control structure */
-    if( ( ret = check_control_input( encControl ) != 0 ) ) {
+    if( ( ret = check_control_input( encControl ) ) != 0  ) {
         silk_assert( 0 );
         RESTORE_STACK;
         return ret;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V593](https://www.viva64.com/en/w/v593/) Consider reviewing the expression of the 'A = B != C' kind. The expression is calculated as following: 'A = (B != C)'. enc_api.c 168