### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/third_party/libmodplug/src/load_dmf.cpp
+++ b/third_party/libmodplug/src/load_dmf.cpp
@@ -118,18 +118,19 @@ BOOL CSoundFile::ReadDMF(const BYTE *lpStream, DWORD dwMemLength)
 			if ((psi->infosize > dwMemLength) || (psi->infosize + dwMemPos + 8 > dwMemLength)) goto dmfexit;
 			if ((psi->infosize >= 8) && (!m_lpszSongComments))
 			{
-			    m_lpszSongComments = new char[psi->infosize]; // changed from CHAR
-				if (m_lpszSongComments)
-				{
-					for (UINT i=0; i<psi->infosize-1; i++)
+				try {
+					m_lpszSongComments = new char[psi->infosize]; // changed from CHAR
+					for (UINT i = 0; i < psi->infosize - 1; i++)
 					{
-						CHAR c = lpStream[dwMemPos+8+i];
+						CHAR c = lpStream[dwMemPos + 8 + i];
 						if ((i % 40) == 39)
 							m_lpszSongComments[i] = 0x0d;
 						else
 							m_lpszSongComments[i] = (c < ' ') ? ' ' : c;
 					}
-					m_lpszSongComments[psi->infosize-1] = 0;
+					m_lpszSongComments[psi->infosize - 1] = 0;
+				}
+				catch (std::bad_alloc& ba) {
 				}
 			}
 			dwMemPos += psi->infosize + 8 - 1;

--- a/third_party/libmodplug/src/sndfile.h
+++ b/third_party/libmodplug/src/sndfile.h
@@ -13,6 +13,8 @@
 #ifndef __SNDFILE_H
 #define __SNDFILE_H
 
+#include <new>
+
 #ifdef UNDER_CE
 int _strnicmp(const char *str1,const char *str2, int n);
 #endif


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'm_lpszSongComments' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. load_dmf.cpp 122