### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/third_party/libmodplug/src/load_far.cpp
+++ b/third_party/libmodplug/src/load_far.cpp
@@ -92,11 +92,14 @@ BOOL CSoundFile::ReadFAR(const BYTE *lpStream, DWORD dwMemLength)
 	{
 		UINT szLen = stlen;
 		if (szLen > dwMemLength - dwMemPos) szLen = dwMemLength - dwMemPos;
-		if ((m_lpszSongComments = new char[szLen + 1]) != NULL)
-		{
-			memcpy(m_lpszSongComments, lpStream+dwMemPos, szLen);
+		try {
+			m_lpszSongComments = new char[szLen + 1];
+			memcpy(m_lpszSongComments, lpStream + dwMemPos, szLen);
 			m_lpszSongComments[szLen] = 0;
 		}
+		catch (std::bad_alloc& ba) {
+		}
+
 		dwMemPos += stlen;
 	}
 	// Reading orders

--- a/third_party/libmodplug/src/sndfile.h
+++ b/third_party/libmodplug/src/sndfile.h
@@ -13,6 +13,8 @@
 #ifndef __SNDFILE_H
 #define __SNDFILE_H
 
+#include <new>
+
 #ifdef UNDER_CE
 int _strnicmp(const char *str1,const char *str2, int n);
 #endif


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'm_lpszSongComments' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. load_far.cpp 95