### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/third_party/libmodplug/src/load_it.cpp
+++ b/third_party/libmodplug/src/load_it.cpp
@@ -221,11 +221,12 @@ BOOL CSoundFile::ReadIT(const BYTE *lpStream, DWORD dwMemLength)
 	// Reading Song Message
 	if ((pifh.special & 0x01) && (pifh.msglength) && (pifh.msglength <= dwMemLength) && (pifh.msgoffset < dwMemLength - pifh.msglength))
 	{
-		m_lpszSongComments = new char[pifh.msglength+1];
-		if (m_lpszSongComments)
-		{
-			memcpy(m_lpszSongComments, lpStream+pifh.msgoffset, pifh.msglength);
+		try {
+			m_lpszSongComments = new char[pifh.msglength + 1];
+			memcpy(m_lpszSongComments, lpStream + pifh.msgoffset, pifh.msglength);
 			m_lpszSongComments[pifh.msglength] = 0;
+		}
+		catch (std::bad_alloc& ba) {
 		}
 	}
 	// Reading orders
@@ -289,12 +290,14 @@ BOOL CSoundFile::ReadIT(const BYTE *lpStream, DWORD dwMemLength)
 		dwMemPos += 8;
 		if ((dwMemPos + len <= dwMemLength) && (len <= MAX_PATTERNS*MAX_PATTERNNAME) && (len >= MAX_PATTERNNAME))
 		{
-			m_lpszPatternNames = new char[len];
-			if (m_lpszPatternNames)
-			{
+			try {
+				m_lpszPatternNames = new char[len];
 				m_nPatternNames = len / MAX_PATTERNNAME;
-				memcpy(m_lpszPatternNames, lpStream+dwMemPos, len);
+				memcpy(m_lpszPatternNames, lpStream + dwMemPos, len);
 			}
+			catch (std::bad_alloc& ba) {
+			}
+
 			dwMemPos += len;
 		}
 	}
@@ -376,8 +379,14 @@ BOOL CSoundFile::ReadIT(const BYTE *lpStream, DWORD dwMemLength)
 	{
 		if ((inspos[nins] > 0) && (inspos[nins] < dwMemLength - sizeof(ITOLDINSTRUMENT)))
 		{
-			INSTRUMENTHEADER *penv = new INSTRUMENTHEADER;
-			if (!penv) continue;
+			INSTRUMENTHEADER *penv;
+			try {
+				penv = new INSTRUMENTHEADER;
+			}
+			catch (std::bad_alloc& ba) {
+				continue;
+			}
+
 			Headers[nins+1] = penv;
 			memset(penv, 0, sizeof(INSTRUMENTHEADER));
 			ITInstrToMPT(lpStream + inspos[nins], penv, pifh.cmwt);

--- a/third_party/libmodplug/src/sndfile.h
+++ b/third_party/libmodplug/src/sndfile.h
@@ -13,6 +13,8 @@
 #ifndef __SNDFILE_H
 #define __SNDFILE_H
 
+#include <new>
+
 #ifdef UNDER_CE
 int _strnicmp(const char *str1,const char *str2, int n);
 #endif


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. load_it.cpp
