### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/third_party/libmodplug/src/load_mdl.cpp
+++ b/third_party/libmodplug/src/load_mdl.cpp
@@ -243,11 +243,12 @@ BOOL CSoundFile::ReadMDL(const BYTE *lpStream, DWORD dwMemLength)
 			if (blocklen)
 			{
 				if (m_lpszSongComments) delete [] m_lpszSongComments;
-				m_lpszSongComments = new char[blocklen];
-				if (m_lpszSongComments)
-				{
-					memcpy(m_lpszSongComments, lpStream+dwMemPos, blocklen);
-					m_lpszSongComments[blocklen-1] = 0;
+				try {
+					m_lpszSongComments = new char[blocklen];
+					memcpy(m_lpszSongComments, lpStream + dwMemPos, blocklen);
+					m_lpszSongComments[blocklen - 1] = 0;
+				}
+				catch (std::bad_alloc& ba) {
 				}
 			}
 			break;
@@ -288,7 +289,13 @@ BOOL CSoundFile::ReadMDL(const BYTE *lpStream, DWORD dwMemLength)
 				if (!Headers[nins])
 				{
 					UINT note = 12;
-					if ((Headers[nins] = new INSTRUMENTHEADER) == NULL) break;
+					try {
+						Headers[nins] = new INSTRUMENTHEADER;
+					}
+					catch (std::bad_alloc& ba) {
+						break;
+					}
+
 					INSTRUMENTHEADER *penv = Headers[nins];
 					memset(penv, 0, sizeof(INSTRUMENTHEADER));
 					memcpy(penv->name, lpStream+dwPos+2, 32);

--- a/third_party/libmodplug/src/sndfile.h
+++ b/third_party/libmodplug/src/sndfile.h
@@ -13,6 +13,8 @@
 #ifndef __SNDFILE_H
 #define __SNDFILE_H
 
+#include <new>
+
 #ifdef UNDER_CE
 int _strnicmp(const char *str1,const char *str2, int n);
 #endif


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. load_mdl.cpp