### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/third_party/libmodplug/src/load_mt2.cpp
+++ b/third_party/libmodplug/src/load_mt2.cpp
@@ -251,11 +251,12 @@ BOOL CSoundFile::ReadMT2(LPCBYTE lpStream, DWORD dwMemLength)
 			{
 				DWORD nTxtLen = dwLen;
 				if (nTxtLen > 32000) nTxtLen = 32000;
-				m_lpszSongComments = new char[nTxtLen];  // changed from CHAR
-				if (m_lpszSongComments)
-				{
-					memcpy(m_lpszSongComments, lpStream+dwMemPos+1, nTxtLen-1);
-					m_lpszSongComments[nTxtLen-1] = 0;
+				try {
+					m_lpszSongComments = new char[nTxtLen];  // changed from CHAR
+					memcpy(m_lpszSongComments, lpStream + dwMemPos + 1, nTxtLen - 1);
+					m_lpszSongComments[nTxtLen - 1] = 0;
+				}
+				catch (std::bad_alloc& ba) {
 				}
 			}
 			break;
@@ -402,18 +403,19 @@ BOOL CSoundFile::ReadMT2(LPCBYTE lpStream, DWORD dwMemLength)
 		INSTRUMENTHEADER *penv = NULL;
 		if (iIns <= m_nInstruments)
 		{
-			penv = new INSTRUMENTHEADER;
-			Headers[iIns] = penv;
-			if (penv)
-			{
+			try {
+				penv = new INSTRUMENTHEADER;
+				Headers[iIns] = penv;
 				memset(penv, 0, sizeof(INSTRUMENTHEADER));
 				memcpy(penv->name, pmi->szName, 32);
 				penv->nGlobalVol = 64;
 				penv->nPan = 128;
-				for (UINT i=0; i<NOTE_MAX; i++)
+				for (UINT i = 0; i < NOTE_MAX; i++)
 				{
-					penv->NoteMap[i] = i+1;
+					penv->NoteMap[i] = i + 1;
 				}
+			}
+			catch (std::bad_alloc& ba) {
 			}
 		}
 	#ifdef MT2DEBUG

--- a/third_party/libmodplug/src/sndfile.h
+++ b/third_party/libmodplug/src/sndfile.h
@@ -13,6 +13,8 @@
 #ifndef __SNDFILE_H
 #define __SNDFILE_H
 
+#include <new>
+
 #ifdef UNDER_CE
 int _strnicmp(const char *str1,const char *str2, int n);
 #endif


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. load_mt2.cpp