### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/third_party/libmodplug/src/load_mtm.cpp
+++ b/third_party/libmodplug/src/load_mtm.cpp
@@ -139,18 +139,20 @@ BOOL CSoundFile::ReadMTM(LPCBYTE lpStream, DWORD dwMemLength)
 	if ((pmh->commentsize) && (dwMemPos + pmh->commentsize < dwMemLength))
 	{
 		UINT n = pmh->commentsize;
-		m_lpszSongComments = new char[n+1];
-		if (m_lpszSongComments)
-		{
-			memcpy(m_lpszSongComments, lpStream+dwMemPos, n);
+
+		try {
+			m_lpszSongComments = new char[n + 1];
+			memcpy(m_lpszSongComments, lpStream + dwMemPos, n);
 			m_lpszSongComments[n] = 0;
-			for (UINT i=0; i<n; i++)
+			for (UINT i = 0; i < n; i++)
 			{
 				if (!m_lpszSongComments[i])
 				{
-					m_lpszSongComments[i] = ((i+1) % 40) ? 0x20 : 0x0D;
+					m_lpszSongComments[i] = ((i + 1) % 40) ? 0x20 : 0x0D;
 				}
 			}
+		}
+		catch (std::bad_alloc& ba) {
 		}
 	}
 	dwMemPos += pmh->commentsize;

--- a/third_party/libmodplug/src/sndfile.h
+++ b/third_party/libmodplug/src/sndfile.h
@@ -13,6 +13,8 @@
 #ifndef __SNDFILE_H
 #define __SNDFILE_H
 
+#include <new>
+
 #ifdef UNDER_CE
 int _strnicmp(const char *str1,const char *str2, int n);
 #endif


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'm_lpszSongComments' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. load_mtm.cpp 143