### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/third_party/libmodplug/src/load_pat.cpp
+++ b/third_party/libmodplug/src/load_pat.cpp
@@ -1119,7 +1119,13 @@ BOOL PAT_Load_Instruments(void *c)
 	of->m_nSamples     = pat_numsmp() + 1; // xmms modplug does not use slot zero
 	of->m_nInstruments = pat_numinstr() + 1;
 	for(t=1; t<of->m_nInstruments; t++) { // xmms modplug doesn't use slot zero
-		if( (of->Headers[t] = new INSTRUMENTHEADER) == NULL ) return FALSE;
+		try {
+			of->Headers[t] = new INSTRUMENTHEADER;
+		}
+		catch (std::bad_alloc& ba) {
+			return FALSE;
+		}
+
 		memset(of->Headers[t], 0, sizeof(INSTRUMENTHEADER));
 		PATinst(of->Headers[t], t, pat_smptogm(t));
 	}
@@ -1128,7 +1134,13 @@ BOOL PAT_Load_Instruments(void *c)
 	}
 	// copy last of the mohicans to entry 0 for XMMS modinfo to work....
 	t = of->m_nInstruments - 1;
-	if( (of->Headers[0] = new INSTRUMENTHEADER) == NULL ) return FALSE;
+	try {
+		of->Headers[0] = new INSTRUMENTHEADER;
+	}
+	catch (std::bad_alloc& ba) {
+		return FALSE;
+	}
+
 	memcpy(of->Headers[0], of->Headers[t], sizeof(INSTRUMENTHEADER));
 	memset(of->Headers[0]->name, 0, 32);
 	strncpy((char *)of->Headers[0]->name, "Timidity GM patches", 32);
@@ -1186,10 +1198,15 @@ BOOL CSoundFile::ReadPAT(const BYTE *lpStream, DWORD dwMemLength)
 	for(t=1; t<(int)m_nInstruments; t++) { // xmms modplug doesn't use slot zero
 		WaveHeader hw;
 		char s[32];
-		if( (d = new INSTRUMENTHEADER) == NULL ) {
+
+		try {
+			d = new INSTRUMENTHEADER;
+		}
+		catch (std::bad_alloc& ba) {
 			avoid_reentry = 0;
 			return FALSE;
 		}
+
 		memset(d, 0, sizeof(INSTRUMENTHEADER));
 		Headers[t] = d;
 		sprintf(s, "%s", h->patname);
@@ -1241,10 +1258,15 @@ BOOL CSoundFile::ReadPAT(const BYTE *lpStream, DWORD dwMemLength)
 	}
 	// copy last of the mohicans to entry 0 for XMMS modinfo to work....
 	t = m_nInstruments - 1;
-	if( (Headers[0] = new INSTRUMENTHEADER) == NULL ) {
+
+	try {
+		Headers[0] = new INSTRUMENTHEADER;
+	}
+	catch (std::bad_alloc& ba) {
 		avoid_reentry = 0;
 		return FALSE;
 	}
+
 	memcpy(Headers[0], Headers[t], sizeof(INSTRUMENTHEADER));
 	memset(Headers[0]->name, 0, 32);
 	if( h->patname[0] )

--- a/third_party/libmodplug/src/sndfile.h
+++ b/third_party/libmodplug/src/sndfile.h
@@ -13,6 +13,8 @@
 #ifndef __SNDFILE_H
 #define __SNDFILE_H
 
+#include <new>
+
 #ifdef UNDER_CE
 int _strnicmp(const char *str1,const char *str2, int n);
 #endif


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. load_pat.cpp