### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/third_party/libmodplug/src/load_ult.cpp
+++ b/third_party/libmodplug/src/load_ult.cpp
@@ -64,15 +64,16 @@ BOOL CSoundFile::ReadUlt(const BYTE *lpStream, DWORD dwMemLength)
 	if ((pmh->reserved) && (dwMemPos + pmh->reserved * 32 < dwMemLength))
 	{
 		UINT len = pmh->reserved * 32;
-		m_lpszSongComments = new char[len + 1 + pmh->reserved];
-		if (m_lpszSongComments)
-		{
-			for (UINT l=0; l<pmh->reserved; l++)
+		try {
+			m_lpszSongComments = new char[len + 1 + pmh->reserved];
+			for (UINT l = 0; l < pmh->reserved; l++)
 			{
-				memcpy(m_lpszSongComments+l*33, lpStream+dwMemPos+l*32, 32);
-				m_lpszSongComments[l*33+32] = 0x0D;
+				memcpy(m_lpszSongComments + l * 33, lpStream + dwMemPos + l * 32, 32);
+				m_lpszSongComments[l * 33 + 32] = 0x0D;
 			}
 			m_lpszSongComments[len] = 0;
+		}
+		catch (std::bad_alloc& ba) {
 		}
 		dwMemPos += len;
 	}

--- a/third_party/libmodplug/src/sndfile.h
+++ b/third_party/libmodplug/src/sndfile.h
@@ -13,6 +13,8 @@
 #ifndef __SNDFILE_H
 #define __SNDFILE_H
 
+#include <new>
+
 #ifdef UNDER_CE
 int _strnicmp(const char *str1,const char *str2, int n);
 #endif


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'm_lpszSongComments' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. load_ult.cpp 68