### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/third_party/libmodplug/src/load_xm.cpp
+++ b/third_party/libmodplug/src/load_xm.cpp
@@ -282,7 +282,13 @@ BOOL CSoundFile::ReadXM(const BYTE *lpStream, DWORD dwMemLength)
 		if (dwMemPos + sizeof(XMINSTRUMENTHEADER) >= dwMemLength) return TRUE;
 		pih = (XMINSTRUMENTHEADER *)(lpStream+dwMemPos);
 		if (dwMemPos + bswapLE32(pih->size) > dwMemLength) return TRUE;
-		if ((Headers[iIns] = new INSTRUMENTHEADER) == NULL) continue;
+		try {
+			Headers[iIns] = new INSTRUMENTHEADER;
+		}
+		catch (std::bad_alloc& ba) {
+			continue;
+		}
+
 		memset(Headers[iIns], 0, sizeof(INSTRUMENTHEADER));
 		memcpy(Headers[iIns]->name, pih->name, 22);
 		if ((nsamples = pih->samples) > 0)
@@ -519,12 +525,14 @@ BOOL CSoundFile::ReadXM(const BYTE *lpStream, DWORD dwMemLength)
 		dwMemPos += 8;
 		if ((dwMemPos + len <= dwMemLength) && (len < 16384))
 		{
-			m_lpszSongComments = new char[len+1];
-			if (m_lpszSongComments)
-			{
-				memcpy(m_lpszSongComments, lpStream+dwMemPos, len);
+			try {
+				m_lpszSongComments = new char[len + 1];
+				memcpy(m_lpszSongComments, lpStream + dwMemPos, len);
 				m_lpszSongComments[len] = 0;
 			}
+			catch (std::bad_alloc& ba) {
+			}
+
 			dwMemPos += len;
 		}
 	}
@@ -546,13 +554,14 @@ BOOL CSoundFile::ReadXM(const BYTE *lpStream, DWORD dwMemLength)
 		dwMemPos += 8;
 		if ((dwMemPos + len <= dwMemLength) && (len <= MAX_PATTERNS*MAX_PATTERNNAME) && (len >= MAX_PATTERNNAME))
 		{
-			m_lpszPatternNames = new char[len];
-
-			if (m_lpszPatternNames)
-			{
+			try {
+				m_lpszPatternNames = new char[len];
 				m_nPatternNames = len / MAX_PATTERNNAME;
-				memcpy(m_lpszPatternNames, lpStream+dwMemPos, len);
+				memcpy(m_lpszPatternNames, lpStream + dwMemPos, len);
 			}
+			catch (std::bad_alloc& ba) {
+			}
+
 			dwMemPos += len;
 		}
 	}

--- a/third_party/libmodplug/src/sndfile.h
+++ b/third_party/libmodplug/src/sndfile.h
@@ -13,6 +13,8 @@
 #ifndef __SNDFILE_H
 #define __SNDFILE_H
 
+#include <new>
+
 #ifdef UNDER_CE
 int _strnicmp(const char *str1,const char *str2, int n);
 #endif


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. load_xm.cpp