### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/third_party/libmodplug/src/sndfile.cpp
+++ b/third_party/libmodplug/src/sndfile.cpp
@@ -339,8 +339,13 @@ BOOL CSoundFile::Destroy()
 MODCOMMAND *CSoundFile::AllocatePattern(UINT rows, UINT nchns)
 //------------------------------------------------------------
 {
-	MODCOMMAND *p = new MODCOMMAND[rows*nchns];
-	if (p) memset(p, 0, rows*nchns*sizeof(MODCOMMAND));
+	try {
+		MODCOMMAND *p = new MODCOMMAND[rows*nchns];
+		memset(p, 0, rows*nchns*sizeof(MODCOMMAND));
+	}
+	catch (std::bad_alloc& ba) {
+	}
+
 	return p;
 }
 
@@ -1777,8 +1782,15 @@ BOOL CSoundFile::SetPatternName(UINT nPat, LPCSTR lpszName)
 	{
 		if (!lpszName[0]) return TRUE;
 		UINT len = (nPat+1)*MAX_PATTERNNAME;
-		char *p = new char[len];
-		if (!p) return FALSE;
+
+		char *p;
+		try {
+			p = new char[len];
+		}
+		catch (std::bad_alloc& ba) {
+			return FALSE;
+		}
+
 		memset(p, 0, len);
 		if (m_lpszPatternNames)
 		{

--- a/third_party/libmodplug/src/sndfile.h
+++ b/third_party/libmodplug/src/sndfile.h
@@ -13,6 +13,8 @@
 #ifndef __SNDFILE_H
 #define __SNDFILE_H
 
+#include <new>
+
 #ifdef UNDER_CE
 int _strnicmp(const char *str1,const char *str2, int n);
 #endif


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'p' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. sndfile.cpp