### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/third_party/libmodplug/src/load_abc.cpp
+++ b/third_party/libmodplug/src/load_abc.cpp
@@ -438,6 +438,7 @@ static MMFILE *mmfopen(const char *name, const char *mode)
 		mmfile = (MMFILE *)malloc(len+sizeof(MMFILE));
 	if( !mmfile || len <= 0 ) {
 		fclose(fp);
+		free(mmfile);
 		return NULL;
 	}
 	fseek(fp, 0, SEEK_SET);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V773 The function was exited without releasing the 'mmfile' pointer. A memory leak is possible. load_abc.cpp 441