### PR TITLE
Populate the PUBLIC and PRIVATE interface of libnyquist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,8 +164,11 @@ if (WIN32)
     _disable_warning(4018)
 endif()
 
-target_include_directories(libnyquist PRIVATE
-    ${LIBNYQUIST_ROOT}/include
+target_include_directories(libnyquist
+  PUBLIC
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${LIBNYQUIST_ROOT}/include>
+  PRIVATE
     ${LIBNYQUIST_ROOT}/include/libnyquist
     ${LIBNYQUIST_ROOT}/third_party
     ${LIBNYQUIST_ROOT}/third_party/FLAC/src/include
@@ -198,7 +201,7 @@ set_target_properties(libnyquist
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 
-#target_link_libraries(libnyquist libopus libwavpack)
+target_link_libraries(libnyquist PRIVATE libopus libwavpack)
 
 install(TARGETS libnyquist
         LIBRARY DESTINATION lib
@@ -236,22 +239,22 @@ if(BUILD_EXAMPLE)
         target_compile_definitions(${NQR_EXAMPLE_APP_NAME} PRIVATE __MACOSX_CORE__)
     elseif(LIBNYQUIST_JACK)
         target_compile_definitions(${NQR_EXAMPLE_APP_NAME} PRIVATE __UNIX_JACK__)
-        target_link_libraries(${NQR_EXAMPLE_APP_NAME} PUBLIC jack pthread)
+        target_link_libraries(${NQR_EXAMPLE_APP_NAME} PRIVATE jack pthread)
     elseif(LIBNYQUIST_PULSE)
         target_compile_definitions(${NQR_EXAMPLE_APP_NAME} PRIVATE __LINUX_PULSE__)
-        target_link_libraries(${NQR_EXAMPLE_APP_NAME} PUBLIC pulse pthread)
+        target_link_libraries(${NQR_EXAMPLE_APP_NAME} PRIVATE pulse pthread)
     elseif(LIBNYQUIST_ASOUND)
         target_compile_definitions(${NQR_EXAMPLE_APP_NAME} PRIVATE __LINUX_ALSA__)
-        target_link_libraries(${NQR_EXAMPLE_APP_NAME} PUBLIC asound pthread)
+        target_link_libraries(${NQR_EXAMPLE_APP_NAME} PRIVATE asound pthread)
     else()
         message(FATAL, "On Linux, one of LIBNYQUIST_JACK, LIBNYQUIST_PULSE, or LIBNYQUIST_ASOUND must be set.")
     endif()
 
     target_include_directories(${NQR_EXAMPLE_APP_NAME} PRIVATE
-        ${LIBNYQUIST_ROOT}/include
         ${LIBNYQUIST_ROOT}/examples/src
         ${LIBNYQUIST_ROOT}/third_party
     )
+    target_link_libraries(${NQR_EXAMPLE_APP_NAME} PRIVATE libnyquist)
 
     set_target_properties(${NQR_EXAMPLE_APP_NAME}
         PROPERTIES
@@ -261,13 +264,13 @@ if(BUILD_EXAMPLE)
     )
 
     if(APPLE)
-        set(DARWIN_LIBS
+        target_link_libraries(${NQR_EXAMPLE_APP_NAME} PRIVATE
             "-framework AudioToolbox"
             "-framework AudioUnit"
             "-framework Accelerate"
             "-framework CoreAudio"
-            "-framework Cocoa")
+            "-framework Cocoa"
+        )
     ENDIF(APPLE)
 
-    target_link_libraries(${NQR_EXAMPLE_APP_NAME} PUBLIC ${DARWIN_LIBS} libnyquist libopus libwavpack)
 endif()

--- a/third_party/FLAC/src/include/private/macros.h
+++ b/third_party/FLAC/src/include/private/macros.h
@@ -61,12 +61,12 @@
 #define flac_min(a,b) __min(a,b)
 #endif
 
-#ifndef MIN
-#define MIN(x,y)	((x) <= (y) ? (x) : (y))
+#ifndef flac_min
+#define flac_min(x,y)	((x) <= (y) ? (x) : (y))
 #endif
 
-#ifndef MAX
-#define MAX(x,y)	((x) >= (y) ? (x) : (y))
+#ifndef flac_max
+#define flac_max(x,y)	((x) >= (y) ? (x) : (y))
 #endif
 
 #endif


### PR DESCRIPTION
When linking against libnyquist:
 + include its public headers in the PUBLIC interface.
 + include its libraries dependencies in the PRIVATE interface.

Along the way, update the linkage of the examples, it was made PUBLIC
unnecessarily, it is an executable, it won't be linked against another
target.