### PR TITLE
Fix memory leak when decoding mp3 file.

### DIFF
--- a/src/Mp3Decoder.cpp
+++ b/src/Mp3Decoder.cpp
@@ -54,6 +54,8 @@ void mp3_decode_internal(AudioData * d, const std::vector<uint8_t> & fileData)
 
     d->samples.resize(info.samples);
     std::memcpy(d->samples.data(), info.buffer, sizeof(float) * info.samples);
+
+    delete info.buffer;
 }
 
 //////////////////////


### PR DESCRIPTION
Buffer allocation remains from minimp3 even after deleting NyquistIO object.