### PR TITLE
Fixes #54

### DIFF
--- a/src/Mp3Decoder.cpp
+++ b/src/Mp3Decoder.cpp
@@ -1,16 +1,16 @@
 /*
  Copyright (c) 2019, Dimitri Diakopoulos All rights reserved.
- 
+
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
- 
+
  * Redistributions of source code must retain the above copyright notice, this
  list of conditions and the following disclaimer.
- 
+
  * Redistributions in binary form must reproduce the above copyright notice,
  this list of conditions and the following disclaimer in the documentation
  and/or other materials provided with the distribution.
- 
+
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -37,6 +37,7 @@ using namespace nqr;
 #include "minimp3/minimp3.h"
 #include "minimp3/minimp3_ex.h"
 
+#include <cstdlib>
 #include <cstring>
 
 void mp3_decode_internal(AudioData * d, const std::vector<uint8_t> & fileData)
@@ -55,7 +56,7 @@ void mp3_decode_internal(AudioData * d, const std::vector<uint8_t> & fileData)
     d->samples.resize(info.samples);
     std::memcpy(d->samples.data(), info.buffer, sizeof(float) * info.samples);
 
-    delete info.buffer;
+    std::free(info.buffer);
 }
 
 //////////////////////


### PR DESCRIPTION
Fixes https://github.com/ddiakopoulos/libnyquist/issues/54
This fix replaces the `delete` operator with `std::free()` for the clean up of the allocated memory on `info.buffer`.