### PR TITLE
Update cmake version for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   # install latest cmake
   - |
     if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      CMAKE_URL="https://cmake.org/files/v3.11/cmake-3.11.1-Linux-x86_64.tar.gz";
+      CMAKE_URL="https://cmake.org/files/v3.13/cmake-3.13.1-Linux-x86_64.tar.gz";
       mkdir cmake_latest && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake_latest;
       export PATH=$(pwd)/cmake_latest/bin:${PATH};
     fi


### PR DESCRIPTION
[Travis builds for linux](https://travis-ci.org/github/ddiakopoulos/libnyquist/jobs/767019936) seem to be broken because of outdated cmake version.
This PR will update cmake to the required minimum version.