### PR TITLE
make libwavpack build optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,73 +93,75 @@ endif()
 
 # libwavpack
 
-project(libwavpack)
+if (BUILD_LIBWAVPACK)
+    project(libwavpack)
 
-if(MSVC)
-    # Disable warning C4996 regarding fopen(), strcpy(), etc.
-    _add_define("_CRT_SECURE_NO_WARNINGS")
+    if(MSVC)
+        # Disable warning C4996 regarding fopen(), strcpy(), etc.
+        _add_define("_CRT_SECURE_NO_WARNINGS")
 
-    # Disable warning C4996 regarding unchecked iterators for std::transform,
-    # std::copy, std::equal, et al.
-    _add_define("_SCL_SECURE_NO_WARNINGS")
+        # Disable warning C4996 regarding unchecked iterators for std::transform,
+        # std::copy, std::equal, et al.
+        _add_define("_SCL_SECURE_NO_WARNINGS")
 
-    # Make sure WinDef.h does not define min and max macros which
-    # will conflict with std::min() and std::max().
-    _add_define("NOMINMAX")
+        # Make sure WinDef.h does not define min and max macros which
+        # will conflict with std::min() and std::max().
+        _add_define("NOMINMAX")
+    endif()
+
+    add_definitions(${_NQR_CXX_DEFINITIONS})
+    set(CMAKE_CXX_FLAGS "${_NQR_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
+
+    file(GLOB third_wavpack_src "${LIBNYQUIST_ROOT}/third_party/wavpack/src/*")
+
+    add_library(libwavpack STATIC ${third_wavpack_src})
+
+    set_cxx_version(libwavpack)
+    _set_compile_options(libwavpack)
+
+    if (WIN32)
+        _disable_warning(181)
+        _disable_warning(111)
+        _disable_warning(4267)
+        _disable_warning(4996)
+        _disable_warning(4244)
+        _disable_warning(4701)
+        _disable_warning(4702)
+        _disable_warning(4133)
+        _disable_warning(4100)
+        _disable_warning(4127)
+        _disable_warning(4206)
+        _disable_warning(4312)
+        _disable_warning(4505)
+        _disable_warning(4365)
+        _disable_warning(4005)
+        _disable_warning(4013)
+        _disable_warning(4334)
+        _disable_warning(4703)
+    endif()
+
+    target_include_directories(libwavpack PRIVATE ${LIBNYQUIST_ROOT}/third_party/wavpack/include)
+
+    if (MSVC_IDE)
+        set_target_properties(libwavpack PROPERTIES IMPORT_PREFIX "../")
+    endif()
+
+    set_target_properties(libwavpack
+        PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    set_target_properties(libwavpack PROPERTIES OUTPUT_NAME_DEBUG libwavpack_d)
+
+    install(TARGETS libwavpack
+            LIBRARY DESTINATION lib
+            ARCHIVE DESTINATION lib
+            RUNTIME DESTINATION bin)
+
+    install (TARGETS libwavpack DESTINATION lib)
 endif()
-
-add_definitions(${_NQR_CXX_DEFINITIONS})
-set(CMAKE_CXX_FLAGS "${_NQR_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
-
-file(GLOB third_wavpack_src "${LIBNYQUIST_ROOT}/third_party/wavpack/src/*")
-
-add_library(libwavpack STATIC ${third_wavpack_src})
-
-set_cxx_version(libwavpack)
-_set_compile_options(libwavpack)
-
-if (WIN32)
-    _disable_warning(181)
-    _disable_warning(111)
-    _disable_warning(4267)
-    _disable_warning(4996)
-    _disable_warning(4244)
-    _disable_warning(4701)
-    _disable_warning(4702)
-    _disable_warning(4133)
-    _disable_warning(4100)
-    _disable_warning(4127)
-    _disable_warning(4206)
-    _disable_warning(4312)
-    _disable_warning(4505)
-    _disable_warning(4365)
-    _disable_warning(4005)
-    _disable_warning(4013)
-    _disable_warning(4334)
-    _disable_warning(4703)
-endif()
-
-target_include_directories(libwavpack PRIVATE ${LIBNYQUIST_ROOT}/third_party/wavpack/include)
-
-if (MSVC_IDE)
-    set_target_properties(libwavpack PROPERTIES IMPORT_PREFIX "../")
-endif()
-
-set_target_properties(libwavpack
-    PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
-
-set_target_properties(libwavpack PROPERTIES OUTPUT_NAME_DEBUG libwavpack_d)
-
-install(TARGETS libwavpack
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        RUNTIME DESTINATION bin)
-
-install (TARGETS libwavpack DESTINATION lib)
 
 #-------------------------------------------------------------------------------
 
@@ -174,6 +176,7 @@ file(GLOB wavpack_src     "${LIBNYQUIST_ROOT}/third_party/wavpack/src/*")
 add_library(libnyquist STATIC
     ${nyquist_include}
     ${nyquist_src}
+    ${wavpack_src}
 )
 
 set_cxx_version(libnyquist)
@@ -221,7 +224,7 @@ set_target_properties(libnyquist
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 
-target_link_libraries(libnyquist PRIVATE libwavpack)
+#target_link_libraries(libnyquist PRIVATE libwavpack)
 
 install(TARGETS libnyquist
         LIBRARY DESTINATION lib


### PR DESCRIPTION
The work to make wavpack a source-included library like all the other referenced libraries was almost complete, but not quite. This PR makes the libwavpack build optional like all the other builds, and source-includes libwavpack directly into libnyquist. The advantage is that consumers of libnyquist need only include libnyquist, rather than libnyquist and libwavpack