### PR TITLE
Add prefix to CMake build variables and silence some warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,12 @@ include(CXXhelpers)
 if (CMAKE_OSX_ARCHITECTURES)
     if(CMAKE_OSX_SYSROOT MATCHES ".*iphoneos.*")
         # RtAudio is not portable to ios currently
-        option(BUILD_EXAMPLE "Build example application" OFF)
+        option(LIBNYQUIST_BUILD_EXAMPLE "Build example application" OFF)
     else()
-        option(BUILD_EXAMPLE "Build example application" ON)
+        option(LIBNYQUIST_BUILD_EXAMPLE "Build example application" ON)
     endif()
 else()
-    option(BUILD_EXAMPLE "Build example application" ON)
+    option(LIBNYQUIST_BUILD_EXAMPLE "Build example application" ON)
 endif()
 
 #-------------------------------------------------------------------------------
@@ -237,7 +237,7 @@ source_group(src FILES ${nyquist_src})
 
 # libnyquist-examples
 
-if(BUILD_EXAMPLE)
+if(LIBNYQUIST_BUILD_EXAMPLE)
 
     set(NQR_EXAMPLE_APP_NAME "libnyquist-examples")
 

--- a/include/libnyquist/Common.h
+++ b/include/libnyquist/Common.h
@@ -26,6 +26,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef LIBNYQUIST_COMMON_H
 #define LIBNYQUIST_COMMON_H
 
+#if defined(__GNUC__) || defined(__MINGW32__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4244) // conversion from X to Y, possible loss of data
+#pragma warning(disable: 4100) // unreferenced formal parameter
+#endif
+
 #include <memory>
 #include <vector>
 #include <algorithm>
@@ -402,7 +411,7 @@ enum WaveFormatCode
     FORMAT_ADPCM = 0x2,         // Microsoft ADPCM Format
     FORMAT_IEEE = 0x3,          // IEEE float/double
     FORMAT_ALAW = 0x6,          // 8-bit ITU-T G.711 A-law
-    FORMAT_MULAW = 0x7,         // 8-bit ITU-T G.711 µ-law
+    FORMAT_MULAW = 0x7,         // 8-bit ITU-T G.711 ï¿½-law
     FORMAT_IMA_ADPCM = 0x11,    // IMA ADPCM Format
     FORMAT_EXT = 0xFFFE         // Set via subformat
 };
@@ -690,5 +699,11 @@ inline void TrimSilenceInterleaved(std::vector<float> & buffer, float v, bool fr
 }
 
 } // end namespace nqr
+
+#if defined(__GNUC__) || defined(__MINGW32__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 #endif

--- a/include/libnyquist/Common.h
+++ b/include/libnyquist/Common.h
@@ -411,7 +411,7 @@ enum WaveFormatCode
     FORMAT_ADPCM = 0x2,         // Microsoft ADPCM Format
     FORMAT_IEEE = 0x3,          // IEEE float/double
     FORMAT_ALAW = 0x6,          // 8-bit ITU-T G.711 A-law
-    FORMAT_MULAW = 0x7,         // 8-bit ITU-T G.711 �-law
+    FORMAT_MULAW = 0x7,         // 8-bit ITU-T G.711 µ-law
     FORMAT_IMA_ADPCM = 0x11,    // IMA ADPCM Format
     FORMAT_EXT = 0xFFFE         // Set via subformat
 };


### PR DESCRIPTION
These changes made it easier for me to use libnyquist in my project:

- Renamed CMake variable `BUILD_EXAMPLE` to `LIBNYQUIST_BUILD_EXAMPLE`
- Silence some warnings in `Common.h` (maybe a proper fix would be better?)