### PR TITLE
Prevent WavPack ASM files from being caught by GLOB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ if (BUILD_LIBWAVPACK)
     add_definitions(${_NQR_CXX_DEFINITIONS})
     set(CMAKE_CXX_FLAGS "${_NQR_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
 
-    file(GLOB third_wavpack_src "${LIBNYQUIST_ROOT}/third_party/wavpack/src/*")
+    file(GLOB third_wavpack_src "${LIBNYQUIST_ROOT}/third_party/wavpack/src/*.c")
 
     add_library(libwavpack STATIC ${third_wavpack_src})
 


### PR DESCRIPTION
The GLOBbing can find the assembly files, but only when some other project has called enable_language(ASM) before libnyquist's CMakeLists.txt. This is mostly a problem when using libnyquist as a subdirectory as part of a project. Fixes #49.