### PR TITLE
Missed a spot in #63 (WavPack source GLOB)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,7 @@ project(libnyquist)
 
 file(GLOB nyquist_include "${LIBNYQUIST_ROOT}/include/libnyquist/*")
 file(GLOB nyquist_src     "${LIBNYQUIST_ROOT}/src/*")
-file(GLOB wavpack_src     "${LIBNYQUIST_ROOT}/third_party/wavpack/src/*")
+file(GLOB wavpack_src     "${LIBNYQUIST_ROOT}/third_party/wavpack/src/*.c")
 
 add_library(libnyquist STATIC
     ${nyquist_include}


### PR DESCRIPTION
Sorry for spamming :sweat:  I just noticed that the wavpack source GLOB happened in two different spots and I missed the other yesterday. I didn't notice before because I had forgotten my workaround of deleting the assembly files during build time from another CMakeLists.txt.