### PR TITLE
Make AVX instruction set opt-out

### DIFF
--- a/cmake/CXXhelpers.cmake
+++ b/cmake/CXXhelpers.cmake
@@ -15,7 +15,9 @@ endfunction()
 
 function(_set_compile_options proj)
     if(MSVC)
-        target_compile_options(${proj} PRIVATE /arch:AVX /Zi )
+		option(LIBNYQUIST_ENABLE_AVX "Enable the use of the AVX instruction set (MSVC only)" ON)
+		
+        target_compile_options(${proj} PRIVATE $<$<BOOL:${LIBNYQUIST_ENABLE_AVX}>:/arch:AVX>  /Zi )
     endif()
 endfunction()
 


### PR DESCRIPTION
I'd prefer not to have options defined in files other than the main CMakeLists.txt, but since the AVX setting is set in a separate file i've had to define the option there as well.

Let me know if this needs changing.

Resolves ddiakopoulos/libnyquist#52