### PR TITLE
Install public headers; de-duplicate install include dir (#1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,8 +236,10 @@ install(TARGETS libnyquist
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
+# NOTE: the install interface include dir is declared once, via
+# $<INSTALL_INTERFACE:include> in target_include_directories() above. Do not also
+# pass INCLUDES DESTINATION here or it lands in INTERFACE_INCLUDE_DIRECTORIES twice.
 
 # install the cmake configuration files
 install(EXPORT libnyquist
@@ -248,7 +250,10 @@ install(EXPORT libnyquist
 
 message(STATUS "CMAKE_INSTALL_INCLUDEDIR: ${CMAKE_INSTALL_INCLUDEDIR}")
 
-# todo, install the headers
+# install the public headers so an installed libnyquist is usable by consumers
+# (matches the $<INSTALL_INTERFACE:include> above: #include <libnyquist/...>)
+install(DIRECTORY "${LIBNYQUIST_ROOT}/include/libnyquist"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 # export the targets for use when libnyquist is included as a subproject
 export(TARGETS libnyquist

--- a/third_party/rtaudio/RtAudio.cpp
+++ b/third_party/rtaudio/RtAudio.cpp
@@ -10119,8 +10119,8 @@ void RtApi :: convertBuffer( char *outBuffer, char *inBuffer, ConvertInfo &info 
 
 void RtApi :: byteSwapBuffer( char *buffer, unsigned int samples, RtAudioFormat format )
 {
-  register char val;
-  register char *ptr;
+  char val;
+  char *ptr;
 
   ptr = buffer;
   if ( format == RTAUDIO_SINT16 ) {


### PR DESCRIPTION
* Install public headers; de-duplicate install include dir, addressing the "todo, install the headers" note

- install(DIRECTORY include/libnyquist ...) so <prefix>/include/libnyquist holds the public headers, matching $<INSTALL_INTERFACE:include>.
- Drop the redundant INCLUDES DESTINATION on install(TARGETS): the install interface include dir is already declared via $<INSTALL_INTERFACE:include> in target_include_directories(), so it was landing in INTERFACE_INCLUDE_DIRECTORIES twice.

Verified: fresh configure/build/install now populates include/libnyquist and lists <prefix>/include only once in the generated config.

* Remove 'register' storage-class from bundled RtAudio (illegal in C++17, breaks CI)